### PR TITLE
Fix: Change default shortcut to avoid Firefox profile switcher conflict

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,7 @@
         "_execute_browser_action": {
             "description": "Default shortcut to toggle pinned status of the active tab",
             "suggested_key": {
-                "default": "Alt+P",
+                "default": "Ctrl+Alt+P",
                 "mac": "MacCtrl+Shift+P"
             }
         }


### PR DESCRIPTION
Fixes https://github.com/bhootd/pin-unpin-tab/issues/37

Changes the default keyboard shortcut from `Alt+P` to `Ctrl+Alt+P` to avoid conflict with Firefox's new profile switcher feature.

**Workaround testing:** Users can customize the shortcut via `about:addons > Extensions > Pin Unpin Tab > gear icon > Manage Extension Shortcuts`. Testing confirmed:
- `Alt+P` - Does not work (intercepted by Firefox profile switcher)
- `Alt+Shift+P` - Does not work (still intercepted by Firefox)
- `Ctrl+Alt+P` - **Works correctly**

Environment:
- Firefox version: 146.0.1
- Extension version: 5.0
- OS: Windows 11 25H2